### PR TITLE
Add SimpleInjector support.

### DIFF
--- a/Kekiri.sln
+++ b/Kekiri.sln
@@ -29,11 +29,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IoC", "IoC", "{DF16D56E-1B8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri.IoC.Autofac", "src\IoC\Autofac\Kekiri.IoC.Autofac.csproj", "{3501637A-ABF5-4F80-BC0E-7B4A8ACD3CC4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri.IoC.SimpleInjector", "src\IoC\SimpleInjector\Kekiri.IoC.SimpleInjector.csproj", "{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri", "src\Library\Kekiri.csproj", "{5827C04B-91A2-42AC-8A99-E23BBB27CD94}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri.UnitTests.Autofac2", "Tests\Kekiri.UnitTests.Autofac2\Kekiri.UnitTests.Autofac2.csproj", "{D2FDBB9B-6280-4D70-98D3-BFBBD0BDB830}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri.UnitTests.Autofac3", "Tests\Kekiri.UnitTests.Autofac3\Kekiri.UnitTests.Autofac3.csproj", "{5219967B-0D18-43B3-ABB5-5505A71EDA57}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kekiri.UnitTests.SimpleInjector", "Tests\Kekiri.UnitTests.SimpleInjector\Kekiri.UnitTests.SimpleInjector.csproj", "{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +73,14 @@ Global
 		{5219967B-0D18-43B3-ABB5-5505A71EDA57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5219967B-0D18-43B3-ABB5-5505A71EDA57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5219967B-0D18-43B3-ABB5-5505A71EDA57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,5 +91,7 @@ Global
 		{3501637A-ABF5-4F80-BC0E-7B4A8ACD3CC4} = {DF16D56E-1B85-4B64-A128-C24EED22E633}
 		{D2FDBB9B-6280-4D70-98D3-BFBBD0BDB830} = {43E5189D-BB90-4EBE-921A-01457419C7BB}
 		{5219967B-0D18-43B3-ABB5-5505A71EDA57} = {43E5189D-BB90-4EBE-921A-01457419C7BB}
+		{FFC8D620-6C3E-4E5C-B447-C36EB610BE94} = {DF16D56E-1B85-4B64-A128-C24EED22E633}
+		{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9} = {43E5189D-BB90-4EBE-921A-01457419C7BB}
 	EndGlobalSection
 EndGlobal

--- a/Tests/Kekiri.UnitTests.SimpleInjector/Feature.cs
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/Feature.cs
@@ -1,0 +1,11 @@
+﻿using Kekiri;
+
+namespace UnitTests.SimpleInjector
+{
+    public enum Feature
+    {
+        [FeatureDescription("Inversion of Control",
+            "The framework supports Inversion of Control.  OOB, it offers integration with SimpleInjector")]
+        IoC
+    }
+}

--- a/Tests/Kekiri.UnitTests.SimpleInjector/Kekiri.UnitTests.SimpleInjector.csproj
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/Kekiri.UnitTests.SimpleInjector.csproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{903AB18E-7DC8-4BCF-A9BB-F301B13F0BA9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Kekiri.UnitTests.SimpleInjector</RootNamespace>
+    <AssemblyName>Kekiri.UnitTests.SimpleInjector</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions, Version=3.0.107.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.0.107\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=3.0.107.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.0.107\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SimpleInjector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\SimpleInjector.2.0.0\lib\net40-client\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Feature.cs" />
+    <Compile Include="SimpleInjector\Using_fakes.cs" />
+    <Compile Include="SimpleInjector\Using_mocks.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IoC\SimpleInjector\Kekiri.IoC.SimpleInjector.csproj">
+      <Project>{ffc8d620-6c3e-4e5c-b447-c36eb610be94}</Project>
+      <Name>Kekiri.IoC.SimpleInjector</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Library\Kekiri.csproj">
+      <Project>{5827c04b-91a2-42ac-8a99-e23bbb27cd94}</Project>
+      <Name>Kekiri</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests/Kekiri.UnitTests.SimpleInjector/Properties/AssemblyInfo.cs
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Kekiri.UnitTests.SimpleInjector")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Kekiri.UnitTests.SimpleInjector")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f433201c-8260-413b-822a-9f16b02b55dd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Kekiri.UnitTests.SimpleInjector/SimpleInjector/Using_fakes.cs
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/SimpleInjector/Using_fakes.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Data.SqlClient;
+using FluentAssertions;
+using Kekiri;
+using Kekiri.IoC.SimpleInjector;
+
+namespace UnitTests.SimpleInjector
+{
+    [Scenario(Feature.IoC)]
+    public class Using_fakes : SimpleInjectorTest
+    {
+        private Orchestrator _orchestrator;
+
+        public class Orchestrator
+        {
+            public Validator Validator { get; private set; }
+            public Executor Executor { get; private set; }
+            public IDataComponent DataComponent { get; private set; }
+
+            public Orchestrator(Validator validator, Executor executor, IDataComponent dataComponent)
+            {
+                Validator = validator;
+                Executor = executor;
+                DataComponent = dataComponent;
+            }
+
+            public int Process()
+            {
+                var data = DataComponent.GetData();
+
+                Validator.Validate(data);
+                return Executor.Execute(data);
+            }
+        }
+
+        public class Validator
+        {
+            public void Validate(string input)
+            {
+                if (string.IsNullOrEmpty(input))
+                {
+                    throw new ArgumentException("Must have a value", "input");
+                }
+            }
+        }
+
+        public class Executor
+        {
+            public WordCounter WordCounter { get; set; }
+
+            public Executor(WordCounter wordCounter)
+            {
+                WordCounter = wordCounter;
+            }
+
+            public int Execute(string input)
+            {
+                return WordCounter.CountWords(input);
+            }
+        }
+
+        public class WordCounter
+        {
+            public int CountWords(string sentence)
+            {
+                return sentence.Split(' ').Length;
+            }
+        }
+
+        public interface IDataComponent
+        {
+            string GetData();
+        }
+
+        public class RealDataComponent : IDataComponent
+        {
+            public string GetData()
+            {
+                using (var connection = new SqlConnection("[YourDatabase]"))
+                {
+                    connection.Open();
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = "SELECT YourField from [YourTable]";
+                        return (string)command.ExecuteScalar();
+                    }
+                }
+            }
+        }
+
+        public class FakeDataComponent : IDataComponent
+        {
+            public string GetData()
+            {
+                return "all your base are belong to us";
+            }
+        }
+
+        [Given]
+        public void Given()
+        {
+            Container.Register(new FakeDataComponent());
+        }
+
+        [When]
+        public void When_resolving_an_instance()
+        {
+            _orchestrator = Container.Resolve<Orchestrator>();
+        }
+
+        [Then]
+        public void It_uses_reals_for_everything()
+        {
+            _orchestrator.Validator.Should().BeOfType<Validator>();
+            _orchestrator.Executor.Should().BeOfType<Executor>();
+            _orchestrator.Executor.WordCounter.Should().BeOfType<WordCounter>();
+        }
+
+        [Then]
+        public void But_explicitly_faked_objects()
+        {
+            _orchestrator.DataComponent.Should().BeOfType<FakeDataComponent>();
+        }
+
+        [Then]
+        public void And_it_computes_the_right_result()
+        {
+            _orchestrator.Process().Should().Be(7);
+        }
+    }
+}

--- a/Tests/Kekiri.UnitTests.SimpleInjector/SimpleInjector/Using_mocks.cs
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/SimpleInjector/Using_mocks.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FluentAssertions;
+using Kekiri;
+using Kekiri.IoC.SimpleInjector;
+using Moq;
+using NUnit.Framework;
+using SimpleInjector;
+
+namespace UnitTests.SimpleInjector
+{
+    [Scenario(Feature.IoC)]
+    public class Using_mocks : SimpleInjectorTest
+    {
+        private string _result;
+
+        public interface ISimpleFeature
+        {
+            string TellMeASecret();
+        }
+
+        public class Executor
+        {
+            private readonly ISimpleFeature _simpleFeature;
+
+            public Executor(ISimpleFeature simpleFeature)
+            {
+                _simpleFeature = simpleFeature;
+            }
+
+            public string Execute()
+            {
+                return _simpleFeature.TellMeASecret();
+            }
+        }
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            IocConfig.BuildContainer = () =>
+            {
+                var container = new Container();
+                container.Register<Executor>();
+                return container;
+            };
+        }
+
+        [Given]
+        public void Given()
+        {
+            var mock = new Mock<ISimpleFeature>();
+            mock.Setup(x => x.TellMeASecret()).Returns("I did it!");
+            Container.Register(mock.Object);
+        }
+
+        [When]
+        public void When()
+        {
+            var executor = Container.Resolve<Executor>();
+            _result = executor.Execute();
+        }
+
+        [Then]
+        public void It_should_get_the_correct_result()
+        {
+            _result.Should().Be("I did it!");
+        }
+    }
+}

--- a/Tests/Kekiri.UnitTests.SimpleInjector/app.config
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/Kekiri.UnitTests.SimpleInjector/packages.config
+++ b/Tests/Kekiri.UnitTests.SimpleInjector/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="3.0.107" targetFramework="net45" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="SimpleInjector" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/build.proj
+++ b/build.proj
@@ -13,6 +13,7 @@
         </MakeDir>
         <Exec Command=".nuget\nuget.exe pack src\library\Kekiri.csproj -OutputDirectory &quot;@(OutputDirectory)&quot; -Properties &quot;configuration=$(Configuration)&quot; -NoPackageAnalysis" /> 
         <Exec Command=".nuget\nuget.exe pack src\IoC\Autofac\Kekiri.IoC.Autofac.csproj -OutputDirectory &quot;@(OutputDirectory)&quot; -Properties &quot;configuration=$(Configuration)&quot; -NoPackageAnalysis" /> 
+        <Exec Command=".nuget\nuget.exe pack src\IoC\SimpleInjector\Kekiri.IoC.SimpleInjector.csproj -OutputDirectory &quot;@(OutputDirectory)&quot; -Properties &quot;configuration=$(Configuration)&quot; -NoPackageAnalysis" /> 
         <Exec Command=".nuget\nuget.exe pack src\tools\tools.nuspec -OutputDirectory &quot;@(OutputDirectory)&quot; -Properties &quot;configuration=$(Configuration)&quot; -NoPackageAnalysis" /> 
     </Target>
 

--- a/src/IoC/Autofac/AutofacFluentTest.cs
+++ b/src/IoC/Autofac/AutofacFluentTest.cs
@@ -7,7 +7,7 @@
         }
     }
 
-    public class AutofacFluentTest<TContext> : IoCFluentTest<TContext>
+    public class AutofacFluentTest<TContext> : IoCFluentTest<TContext> where TContext : class
     {
         public AutofacFluentTest()
             : base(new AutofacContainer())

--- a/src/IoC/SimpleInjector/IocConfig.cs
+++ b/src/IoC/SimpleInjector/IocConfig.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using SIContainer = SimpleInjector.Container;
+
+namespace Kekiri.IoC.SimpleInjector
+{
+    /// <summary>
+    /// Extension points for customizing SimpleInjector behavior.
+    /// </summary>
+    public static class IocConfig
+    {
+        /// <summary>
+        /// Controls container creation.
+        /// </summary>
+        public static Func<SIContainer> BuildContainer;
+    }
+}

--- a/src/IoC/SimpleInjector/Kekiri.IoC.SimpleInjector.csproj
+++ b/src/IoC/SimpleInjector/Kekiri.IoC.SimpleInjector.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FFC8D620-6C3E-4E5C-B447-C36EB610BE94}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Kekiri.IoC.SimpleInjector</RootNamespace>
+    <AssemblyName>Kekiri.IoC.SimpleInjector</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="SimpleInjector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\SimpleInjector.2.0.0\lib\net40-client\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IocConfig.cs" />
+    <Compile Include="SimpleInjectorFluentTest.cs" />
+    <Compile Include="SimpleInjectorContainer.cs" />
+    <Compile Include="SimpleInjectorTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="Kekiri.IoC.SimpleInjector.nuspec" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Library\Kekiri.csproj">
+      <Project>{5827c04b-91a2-42ac-8a99-e23bbb27cd94}</Project>
+      <Name>Kekiri</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/IoC/SimpleInjector/Kekiri.IoC.SimpleInjector.nuspec
+++ b/src/IoC/SimpleInjector/Kekiri.IoC.SimpleInjector.nuspec
@@ -5,15 +5,17 @@
     <title>$id$</title>
     <version>2.1.3</version>
     <authors>$author$</authors>
-    <summary>A low-friction BDD framework</summary>
+    <summary>SimpleInjector extensions for Kekiri</summary>
     <description>$description$</description>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectUrl>http://github.com/chris-peterson/kekiri</projectUrl>
-    <tags>bdd scenario test gherkin cucumber pickles nunit specflow</tags>
-    <copyright>2012-2014</copyright>
+    <tags>bdd scenario test gherkin cucumber pickles ioc di autofac nunit specflow</tags>
+    <copyright>2013-2015</copyright>
     <releaseNotes>
-        Registered objects must be reference types.
     </releaseNotes>
+    <dependencies>
+      <dependency id="Kekiri" version="2.1.3" />
+    </dependencies>
   </metadata>
 </package>

--- a/src/IoC/SimpleInjector/Properties/AssemblyInfo.cs
+++ b/src/IoC/SimpleInjector/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Kekiri.IoC.SimpleInjector")]
+[assembly: AssemblyDescription("An extension of Kekiri to support SimpleInjector-aware ScenarioTests")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Jordan Hayashi")]
+[assembly: AssemblyProduct("Kekiri.IoC.SimpleInjector")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a53aff32-b538-49ff-a8b8-0eaf201bebc8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("2.1.2")]
+[assembly: AssemblyInformationalVersionAttribute("2.1.2")]

--- a/src/IoC/SimpleInjector/SimpleInjectorContainer.cs
+++ b/src/IoC/SimpleInjector/SimpleInjectorContainer.cs
@@ -1,0 +1,35 @@
+using System;
+using SIContainer = SimpleInjector.Container;
+
+namespace Kekiri.IoC.SimpleInjector
+{
+    internal class SimpleInjectorContainer : Container
+    {
+        private bool _fakesRegistered;
+
+        private static readonly Lazy<SIContainer> Container = new Lazy<SIContainer>(() =>
+        {
+            return IocConfig.BuildContainer == null
+                ? new SIContainer()
+                : IocConfig.BuildContainer();
+        });
+
+        protected override T OnResolve<T>()
+        {
+            var container = Container.Value;
+
+            if (!_fakesRegistered)
+            {
+                foreach (var obj in Fakes)
+                {
+                    container.Register(obj.GetType(), () => obj);
+                    foreach (var i in obj.GetType().GetInterfaces())
+                        container.Register(i, () => obj);
+                }
+                _fakesRegistered = true;
+            }
+
+            return Container.Value.GetInstance<T>();
+        }
+    }
+}

--- a/src/IoC/SimpleInjector/SimpleInjectorFluentTest.cs
+++ b/src/IoC/SimpleInjector/SimpleInjectorFluentTest.cs
@@ -1,0 +1,17 @@
+﻿namespace Kekiri.IoC.SimpleInjector
+{
+    public class SimpleInjectorFluentTest : IoCFluentTest
+    {
+        public SimpleInjectorFluentTest() : base(new SimpleInjectorContainer())
+        {
+        }
+    }
+
+    public class SimpleInjectorFluentTest<TContext> : IoCFluentTest<TContext> where TContext : class
+    {
+        public SimpleInjectorFluentTest()
+            : base(new SimpleInjectorContainer())
+        {
+        }
+    }
+}

--- a/src/IoC/SimpleInjector/SimpleInjectorTest.cs
+++ b/src/IoC/SimpleInjector/SimpleInjectorTest.cs
@@ -1,0 +1,9 @@
+﻿namespace Kekiri.IoC.SimpleInjector
+{
+    public class SimpleInjectorTest : IoCTest
+    {
+        public SimpleInjectorTest() : base(new SimpleInjectorContainer())
+        {
+        }
+    }
+}

--- a/src/IoC/SimpleInjector/app.config
+++ b/src/IoC/SimpleInjector/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/IoC/SimpleInjector/packages.config
+++ b/src/IoC/SimpleInjector/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SimpleInjector" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/src/Library/IoC/Container.cs
+++ b/src/Library/IoC/Container.cs
@@ -52,9 +52,9 @@ namespace Kekiri.IoC
             }
         }
 
-        protected abstract T OnResolve<T>();
+        protected abstract T OnResolve<T>() where T : class;
 
-        public T Resolve<T>()
+        public T Resolve<T>() where T : class
         {
             _registrationClosed = true;
 

--- a/src/Library/IoC/IoCFluentTest.cs
+++ b/src/Library/IoC/IoCFluentTest.cs
@@ -18,7 +18,7 @@ namespace Kekiri.IoC
         }
     }
 
-    public abstract class IoCFluentTest<TContext> : FluentTest, IContainerAccessor
+    public abstract class IoCFluentTest<TContext> : FluentTest, IContainerAccessor where TContext : class
     {
         protected internal Container Container;
 


### PR DESCRIPTION
More or less copied what you've got for Autofac. SimpleInjector doesn't have built-in assembly scanning though, so the main difference between the two is the onus is on the user to build this container at setup time. Also, not worrying about scopes currently.