### PR TITLE
update build.bat to probe for version of msbuild compatible with C# 6

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,5 @@
-%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe %~dp0\build.proj /p:Configuration=Release
+@rem Add path to MSBuild Binaries
+@if exist "%ProgramFiles%\MSBuild\14.0\bin" set PATH=%ProgramFiles%\MSBuild\14.0\bin;%PATH%
+@if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" set PATH=%ProgramFiles(x86)%\MSBuild\14.0\bin;%PATH%
+
+msbuild %~dp0\build.proj /p:Configuration=Release


### PR DESCRIPTION
This addresses GH-11 to add logic into the build.bat file that mirrors that of `VsDevCmd.bat` in `C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools`, allowing the build to complete successfully.

Alternatively, I could amend to simply make use of `vsvars32.bat`.
