### PR TITLE
Fixed typed context's with xUnit

### DIFF
--- a/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Scenario_with_typed_context.cs
+++ b/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Scenario_with_typed_context.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Kekiri.TestRunner.xUnit;
+using Xunit;
+
+namespace Kekiri.Examples.xUnit
+{
+    public class Scenario_with_typed_context : Scenarios<MyContext>
+    {
+        [Scenario]
+        public void Can_add_one_plus_two()
+        {
+            Given(a_number, 1)
+                .And(another_number, 2);
+            When(adding_them_up);
+            Then(The_sum_is, 3);
+        }
+
+        private void a_number(int a)
+        {
+            Context.Value1 = a;
+        }
+
+        private void another_number(int b)
+        {
+            Context.Value2 = b;
+        }
+
+        private void adding_them_up()
+        {
+            Context.Sum = Context.Value1 + Context.Value2;
+        }
+
+        private void The_sum_is(int sum)
+        {
+            Assert.Equal(sum, Context.Sum);
+        }
+    }
+
+    public class MyContext
+    {
+        public int Value1 { get; set; }
+
+        public int Value2 { get; set; }
+
+        public int Sum { get; set; }
+    }
+}

--- a/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/Infrastructure/ScenarioDiscoverer.cs
+++ b/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/Infrastructure/ScenarioDiscoverer.cs
@@ -18,7 +18,7 @@ namespace Kekiri.TestRunner.xUnit.Infrastructure
             IAttributeInfo factAttribute)
         {
 
-            if(!typeof(Scenarios).GetTypeInfo().IsAssignableFrom(testMethod.TestClass.Class.ToRuntimeType()))
+            if(!typeof(ScenarioBase).GetTypeInfo().IsAssignableFrom(testMethod.TestClass.Class.ToRuntimeType()))
                 throw new NotSupportedException("The Scenario attribute can only be placed on a class inheriting from Kekiri.TestRunner.xUnit.Scenarios");
 
             return new ScenarioTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);

--- a/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/ScenarioOutlineAttribute.cs
+++ b/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/ScenarioOutlineAttribute.cs
@@ -6,7 +6,7 @@ namespace Kekiri.TestRunner.xUnit
 {
     [XunitTestCaseDiscoverer("Kekiri.TestRunner.xUnit.Infrastructure.ScenarioOutlineDiscoverer", "Kekiri.TestRunner.xUnit")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class ScenarioOutlineAttribute : FactAttribute
+    public class ScenarioOutlineAttribute : TheoryAttribute
     {
     }
 }


### PR DESCRIPTION
Fixed an issue that was preventing xUnit from finding Scenarios that inherited from the generic Scenarios<> class.