### PR TITLE
Fixed a bug that would cause ScenarioOutlines to sometimes not run

### DIFF
--- a/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Kekiri.Examples.xUnit.csproj
+++ b/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Kekiri.Examples.xUnit.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <DebugType>portable</DebugType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Kekiri.Examples.xUnit</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <IsPackable>false</IsPackable>
@@ -12,11 +11,8 @@
     <ProjectReference Include="..\Kekiri.TestRunner.xUnit\Kekiri.TestRunner.xUnit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Scenario_with_typed_context.cs
+++ b/src/TestRunner/xUnit/Kekiri.Examples.xUnit/Scenario_with_typed_context.cs
@@ -16,6 +16,17 @@ namespace Kekiri.Examples.xUnit
             Then(The_sum_is, 3);
         }
 
+        [ScenarioOutline]
+        [Example(1, 2, 3)]
+        [Example(2, 3, 5)]
+        public void Can_add_any_two_numbers(int a, int b, int expectedResult)
+        {
+            Given(a_number, a)
+                .And(another_number, b);
+            When(adding_them_up);
+            Then(The_sum_is, expectedResult);
+        }
+
         private void a_number(int a)
         {
             Context.Value1 = a;

--- a/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/Infrastructure/ScenarioOutlineDiscoverer.cs
+++ b/src/TestRunner/xUnit/Kekiri.TestRunner.xUnit/Infrastructure/ScenarioOutlineDiscoverer.cs
@@ -18,7 +18,7 @@ namespace Kekiri.TestRunner.xUnit.Infrastructure
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
             IAttributeInfo theoryAttribute, object[] dataRow)
         {
-            if(!typeof(Scenarios).GetTypeInfo().IsAssignableFrom(testMethod.TestClass.Class.ToRuntimeType()))
+            if(!typeof(ScenarioBase).GetTypeInfo().IsAssignableFrom(testMethod.TestClass.Class.ToRuntimeType()))
                 throw new NotSupportedException("The ScenarioOutline attribute can only be placed on a class inheriting from Kekiri.TestRunner.xUnit.Scenarios");
 
             return new IXunitTestCase[] {new ScenarioTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow)};


### PR DESCRIPTION
This change fixes a bug that causes ScenarioOutline's to not actually run when inheriting from the Scenarios<T> class (it works fine when inheriting from the non-generic Scenarios.