### PR TITLE
Improve NUnit integration supporting several Scenarios in a Feature class.

### DIFF
--- a/src/Kekiri/Impl/StepMethodInvoker.cs
+++ b/src/Kekiri/Impl/StepMethodInvoker.cs
@@ -31,7 +31,7 @@ namespace Kekiri.Impl
 
         public virtual Task InvokeAsync(ScenarioBase scenario)
         {
-            var returnValue = Method.Invoke(Method.IsStatic ? null : scenario, Parameters.Select(p => p.Value).ToArray());
+            var returnValue = Method.Invoke(Method.IsStatic ? null : scenario.StepsCallerInstance, Parameters.Select(p => p.Value).ToArray());
 
             if (returnValue is Task returnTask)
             {

--- a/src/Kekiri/ScenarioBase.cs
+++ b/src/Kekiri/ScenarioBase.cs
@@ -20,7 +20,14 @@ namespace Kekiri
             // ReSharper disable once DoNotCallOverridableMethodsInConstructor
             var reportTarget = CreateReportTarget();
             _scenarioRunner = new ScenarioRunner(this, reportTarget);
+            StepsCallerInstance = this;
         }
+
+        /// <summary>
+        /// Gets or sets the instance defining the steps methods.
+        /// </summary>
+        /// <value>The steps caller instance.</value>
+        public object StepsCallerInstance { get; set; }
 
         public virtual async Task RunAsync()
         {

--- a/src/TestRunner/NUnit/Kekiri.Examples.NUnit/Calculator/Calculator.cs
+++ b/src/TestRunner/NUnit/Kekiri.Examples.NUnit/Calculator/Calculator.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Kekiri.NUnit;
+using NUnit.Framework;
+using ScenarioAttribute = Kekiri.NUnit.ScenarioAttribute;
+
+namespace Kekiri.Examples.NUnit.Calculator
+{
+    [Feature]
+    public class Calculator : FeatureBase
+    {
+        Calculator2 _calculator;
+
+        [Scenario]
+        public void Adding_two_numbers()
+        {
+            Given(a_calculator)
+               .And(the_user_enters_OPERAND1, 50m)
+                .And(the_user_enters_OPERAND2, 70m);
+            When(adding);
+            Then(the_result_is_EXPECTED, 120m);
+        }
+
+        [Scenario]
+        public void Divide_by_zero()
+        {
+            Given(a_calculator)
+                .And(the_user_enters_OPERAND1, 5m)
+                .And(the_user_enters_OPERAND2, 0m);
+            When(dividing).Throws();
+            Then(an_exception_is_raised);
+        }
+
+        [Scenario]
+        public void Subtracting_two_numbers()
+        {
+            Given(a_calculator)
+                .And(the_user_enters_OPERAND1, 70m)
+                .And(the_user_enters_OPERAND2, 50m);
+            When(subtracting);
+            Then(the_result_is_EXPECTED, 20m);
+        }
+
+        void a_calculator()
+        {
+            _calculator = new Calculator2();
+        }
+
+        void the_user_enters_OPERAND1(decimal operand1)
+        {
+            _calculator.Operand1 = operand1;
+        }
+
+        void the_user_enters_OPERAND2(decimal operand2)
+        {
+            _calculator.Operand2 = operand2;
+        }
+
+        void the_result_is_EXPECTED(decimal expected)
+        {
+            Assert.AreEqual(expected, _calculator.Result);
+        }
+
+        void subtracting()
+        {
+            _calculator.Subtract();
+        }
+
+        void adding()
+        {
+            _calculator.Add();
+        }
+
+        void dividing()
+        {
+            _calculator.Divide();
+        }
+
+        void an_exception_is_raised()
+        {
+            Catch<DivideByZeroException>();
+        }
+    }
+
+    class Calculator2
+    {
+        public decimal Operand1 { get; set; }
+        public decimal Operand2 { get; set; }
+
+        public decimal Result { get; set; }
+
+        public void Add()
+        {
+            Result = Operand1 + Operand2;
+        }
+
+        public void Subtract()
+        {
+            Result = Operand1 - Operand2;
+        }
+
+        public void Divide()
+        {
+            Result = Operand1 / Operand2;
+        }
+    }
+}

--- a/src/TestRunner/NUnit/Kekiri.NUnit/FeatureAttribute.cs
+++ b/src/TestRunner/NUnit/Kekiri.NUnit/FeatureAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Kekiri.NUnit
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class FeatureAttribute : TestFixtureAttribute
+    {
+    }
+}

--- a/src/TestRunner/NUnit/Kekiri.NUnit/FeatureBase.cs
+++ b/src/TestRunner/NUnit/Kekiri.NUnit/FeatureBase.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Threading.Tasks;
+using static Kekiri.ScenarioBase;
+
+namespace Kekiri.NUnit
+{
+    public class FeatureBase
+    {
+        NUnitScenario scenario;
+
+        public void Initialize()
+        {
+            Scenario = new NUnitScenario { StepsCallerInstance = this };
+        }
+
+        internal NUnitScenario Scenario { get => scenario; set => scenario = value; }
+
+        public virtual Task RunAsync()
+        {
+            return Scenario.RunAsync();
+        }
+
+        protected TException Catch<TException>() where TException : Exception
+        {
+            return Scenario.Catch<TException>();
+        }
+
+        protected GivenOptions Given(Action action)
+        {
+            return Scenario.Given(action);
+        }
+
+        protected GivenOptions GivenAsync(Func<Task> action)
+        {
+            return Scenario.GivenAsync(action);
+        }
+
+        protected GivenOptions Given<T>(Action<T> action, T a)
+        {
+            return Scenario.Given(action, a);
+        }
+
+        protected GivenOptions GivenAsync<T>(Func<T, Task> action, T a)
+        {
+            return Scenario.GivenAsync(action, a);
+        }
+
+        protected GivenOptions Given<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return Scenario.Given(action, a, b);
+        }
+
+        protected GivenOptions GivenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return Scenario.GivenAsync(action, a, b);
+        }
+
+        protected GivenOptions Given<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.Given(action, a, b, c);
+        }
+
+        protected GivenOptions GivenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.GivenAsync(action, a, b, c);
+        }
+
+        protected GivenOptions Given<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return Scenario.Given<TStep>(parameterValues);
+        }
+
+        protected WhenOptions When(Action action)
+        {
+            return Scenario.When(action);
+        }
+
+        protected WhenOptions WhenAsync(Func<Task> action)
+        {
+            return Scenario.WhenAsync(action);
+        }
+
+        protected WhenOptions When<T>(Action<T> action, T a)
+        {
+            return Scenario.When(action, a);
+        }
+
+        protected WhenOptions WhenAsync<T>(Func<T, Task> action, T a)
+        {
+            return Scenario.WhenAsync(action, a);
+        }
+
+        protected WhenOptions When<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return Scenario.When(action, a, b);
+        }
+
+        protected WhenOptions WhenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return Scenario.WhenAsync(action, a, b);
+        }
+
+        protected WhenOptions When<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.When(action, a, b, c);
+        }
+
+        protected WhenOptions WhenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.WhenAsync(action, a, b, c);
+        }
+
+        protected WhenOptions When<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return Scenario.When<TStep>(parameterValues);
+        }
+
+        protected ThenOptions Then(Action action)
+        {
+            return Scenario.Then(action);
+        }
+
+        protected ThenOptions ThenAsync(Func<Task> action)
+        {
+            return Scenario.ThenAsync(action);
+        }
+
+        protected ThenOptions Then<T>(Action<T> action, T a)
+        {
+            return Scenario.Then(action, a);
+        }
+
+        protected ThenOptions ThenAsync<T>(Func<T, Task> action, T a)
+        {
+            return Scenario.ThenAsync(action, a);
+        }
+
+        protected ThenOptions Then<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return Scenario.Then(action, a, b);
+        }
+
+        protected ThenOptions ThenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return Scenario.ThenAsync(action, a, b);
+        }
+
+        protected ThenOptions Then<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.Then(action, a, b, c);
+        }
+
+        protected ThenOptions ThenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return Scenario.ThenAsync(action, a, b, c);
+        }
+
+        protected ThenOptions Then<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return Scenario.Then<TStep>(parameterValues);
+        }
+    }
+
+    class NUnitScenario : ScenarioBase
+    {
+        public new TException Catch<TException>() where TException : Exception
+        {
+            return base.Catch<TException>();
+        }
+
+        #region Given
+        public new GivenOptions Given(Action action)
+        {
+            return base.Given(action);
+        }
+
+        public new GivenOptions GivenAsync(Func<Task> action)
+        {
+            return base.GivenAsync(action);
+        }
+
+        public new GivenOptions Given<T>(Action<T> action, T a)
+        {
+            return base.Given(action, a);
+        }
+
+        public new GivenOptions GivenAsync<T>(Func<T, Task> action, T a)
+        {
+            return base.GivenAsync(action, a);
+        }
+
+        public new GivenOptions Given<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return base.Given(action, a, b);
+        }
+
+        public new GivenOptions GivenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return base.GivenAsync(action, a, b);
+        }
+
+        public new GivenOptions Given<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return base.Given(action, a, b, c);
+        }
+
+        public new GivenOptions GivenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return base.GivenAsync(action, a, b, c);
+        }
+
+        public new GivenOptions Given<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return base.Given<TStep>(parameterValues);
+        }
+        #endregion
+
+        #region When
+        public new WhenOptions When(Action action)
+        {
+            return base.When(action);
+        }
+
+        public new WhenOptions WhenAsync(Func<Task> action)
+        {
+            return base.WhenAsync(action);
+        }
+
+        public new WhenOptions When<T>(Action<T> action, T a)
+        {
+            return base.When(action, a);
+        }
+
+        public new WhenOptions WhenAsync<T>(Func<T, Task> action, T a)
+        {
+            return base.WhenAsync(action, a);
+        }
+
+        public new WhenOptions When<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return base.When(action, a, b);
+        }
+
+        public new WhenOptions WhenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return base.WhenAsync(action, a, b);
+        }
+
+        public new WhenOptions When<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return base.When(action, a, b, c);
+        }
+
+        public new WhenOptions WhenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return base.WhenAsync(action, a, b, c);
+        }
+
+        public new WhenOptions When<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return base.When<TStep>(parameterValues);
+        }
+        #endregion
+
+        #region Then
+        public new ThenOptions Then(Action action)
+        {
+            return base.Then(action);
+        }
+
+        public new ThenOptions ThenAsync(Func<Task> action)
+        {
+            return base.ThenAsync(action);
+        }
+
+        public new ThenOptions Then<T>(Action<T> action, T a)
+        {
+            return base.Then(action, a);
+        }
+
+        public new ThenOptions ThenAsync<T>(Func<T, Task> action, T a)
+        {
+            return base.ThenAsync(action, a);
+        }
+
+        public new ThenOptions Then<T1, T2>(Action<T1, T2> action, T1 a, T2 b)
+        {
+            return base.Then(action, a, b);
+        }
+
+        public new ThenOptions ThenAsync<T1, T2>(Func<T1, T2, Task> action, T1 a, T2 b)
+        {
+            return base.ThenAsync(action, a, b);
+        }
+
+        public new ThenOptions Then<T1, T2, T3>(Action<T1, T2, T3> action, T1 a, T2 b, T3 c)
+        {
+            return base.Then(action, a, b, c);
+        }
+
+        public new ThenOptions ThenAsync<T1, T2, T3>(Func<T1, T2, T3, Task> action, T1 a, T2 b, T3 c)
+        {
+            return base.ThenAsync(action, a, b, c);
+        }
+
+        public new ThenOptions Then<TStep>(params object[] parameterValues) where TStep : Step
+        {
+            return base.Then<TStep>(parameterValues);
+        }
+        #endregion
+    }
+}

--- a/src/TestRunner/NUnit/Kekiri.NUnit/ScenarioAttribute.cs
+++ b/src/TestRunner/NUnit/Kekiri.NUnit/ScenarioAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Kekiri.NUnit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ScenarioAttribute : TestAttribute, ITestAction
+    {
+        public void BeforeTest(ITest test)
+        {
+            (test.Fixture as FeatureBase).Initialize();
+        }
+
+        public void AfterTest(ITest test)
+        {
+            (test.Fixture as FeatureBase).RunAsync().Wait();
+        }
+
+        public ActionTargets Targets => ActionTargets.Test | ActionTargets.Suite;
+    }
+}


### PR DESCRIPTION
When designing BDD tests, Scenarios in the same Feature share lots of testing functionality and it's easier to organize tests in a single Feature class with several Scenarios in that class.

For the integration with NUnit we'd like to map Features to Tests Fixtures and Scenarios to Tests, these patches adds the following attributes:
 * [FeatureAttribute](https://github.com/fluendo/kekiri/blob/aa10f9412650b2fb5c8062738066f64b9b90f0bb/src/TestRunner/NUnit/Kekiri.NUnit/FeatureAttribute.cs): inherits from TestFixtureAttribute and should be used in a test class to define a Feature
 * [ScenarioAttribute](https://github.com/fluendo/kekiri/blob/aa10f9412650b2fb5c8062738066f64b9b90f0bb/src/TestRunner/NUnit/Kekiri.NUnit/ScenarioAttribute.cs): inherits from TestAttribute and should used in a function to define a test Scenario

In NUnit a test can run custom functions before and after the tests, we use them to [setup the Scenario before the test](https://github.com/fluendo/kekiri/blob/aa10f9412650b2fb5c8062738066f64b9b90f0bb/src/TestRunner/NUnit/Kekiri.NUnit/ScenarioAttribute.cs#L12) and to [automatically run the ScenarioRunner after the test](https://github.com/fluendo/kekiri/blob/aa10f9412650b2fb5c8062738066f64b9b90f0bb/src/TestRunner/NUnit/Kekiri.NUnit/ScenarioAttribute.cs#L17), providing a seamless integration with NUnit and Visual Studio without additional work for the user and it also adds support for several Scenarios inside the same Feature test.

The new [Calculator.cs](https://github.com/fluendo/kekiri/blob/aa10f9412650b2fb5c8062738066f64b9b90f0bb/src/TestRunner/NUnit/Kekiri.Examples.NUnit/Calculator/Calculator.cs) test provides an example of how a test could be written for NUnit with these changes.

I tried to be as less intrusive as possible in Kekiri's core and since Scenario's Given, When, That are protected I had to proxy them in the NUnitScenario:ScenarioBase class.

