### PR TITLE
Create Autofac container once per test run

### DIFF
--- a/src/IoC/Kekiri.IoC.Autofac/AutofacContainer.cs
+++ b/src/IoC/Kekiri.IoC.Autofac/AutofacContainer.cs
@@ -10,7 +10,7 @@ namespace Kekiri.IoC.Autofac
 {
     class AutofacContainer : Container, IDisposable
     {
-        readonly CustomizeBehaviorApi _customizations;
+        static CustomizeBehaviorApi _customizations;
 
         public AutofacContainer(CustomizeBehaviorApi customizations)
         {
@@ -23,7 +23,7 @@ namespace Kekiri.IoC.Autofac
         {
             if (_lifetimeScope == null)
             {
-                _lifetimeScope = BuildContainer().BeginLifetimeScope(
+                _lifetimeScope = Container.BeginLifetimeScope(
                     builder =>
                     {
                         foreach (var obj in Fakes)
@@ -47,7 +47,7 @@ namespace Kekiri.IoC.Autofac
             }
         }
 
-        IContainer BuildContainer()
+        static readonly Lazy<IContainer> _container = new Lazy<IContainer>(() =>
         {
             var assemblies = Directory.GetFiles(AppContext.BaseDirectory, "*.dll")
                 .Select(f => Path.GetFileNameWithoutExtension(f))
@@ -65,11 +65,14 @@ namespace Kekiri.IoC.Autofac
                 {
                     containerBuilder.RegisterModule(module);
                 }
+
                 return containerBuilder.Build();
             }
 
             return _customizations.BuildContainer(assemblies);
-        }
+        });
+
+        private IContainer Container => _container.Value;
 
         // Adapted from http://www.michael-whelan.net/replacing-appdomain-in-dotnet-core/
         static IEnumerable<Assembly> GetReferencingAssemblies(string assemblyName)

--- a/src/IoC/Kekiri.IoC.Autofac/Kekiri.IoC.Autofac.csproj
+++ b/src/IoC/Kekiri.IoC.Autofac/Kekiri.IoC.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Copyright>2012-2018</Copyright>
+    <Copyright>2012-2019</Copyright>
     <TargetFramework>netstandard1.6</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Kekiri.IoC.Autofac</AssemblyName>
@@ -9,9 +9,9 @@
     <PackageId>Kekiri.IoC.Autofac</PackageId>
     <PackageTags>bdd;scenario;test;gherkin;cucumber;pickles;nunit;specflow</PackageTags>
     <PackageReleaseNotes>
-New features:
+Bug fixes:
 
-- Update dependencies
+- Underlying Autofac IContainer instances were being built multiple times per test run.  Since container behavior configuration is a one-time action (and containers support scopes), there's no reason to create more than one IContainer  By moving to a singleton, large test suites will see a performance gain.
 
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/chris-peterson/kekiri#autofac</PackageProjectUrl>
@@ -19,7 +19,7 @@ New features:
     <RepositoryType>git</RepositoryType>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
     <Authors>Chris Peterson</Authors>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <Company />
     <Product />
     <Description>Autofac IoC integration for Kekiri</Description>


### PR DESCRIPTION
Previously, `IContainer` instances were being build created multiple times per test run.  Given configuration is static, there's no reason to do this.  By moving `IContainer` to a singleton, large test suites will likely see a performance gain.

Anecdotally, this new version made one test suite go from ~24 seconds to < 4.